### PR TITLE
common: Import phone link sepolicy for non-Qcom devices

### DIFF
--- a/common/msft/private/file_contexts
+++ b/common/msft/private/file_contexts
@@ -1,0 +1,1 @@
+/system_ext/bin/virtual_keyboard u:object_r:virtual_keyboard_exec:s0

--- a/common/msft/private/priv_app.te
+++ b/common/msft/private/priv_app.te
@@ -1,0 +1,1 @@
+allow priv_app virtual_keyboard_service:service_manager find;

--- a/common/msft/private/service.te
+++ b/common/msft/private/service.te
@@ -1,0 +1,2 @@
+type virtual_keyboard_service,      service_manager_type;
+type cross_device_service,          app_api_service, system_server_service, service_manager_type;

--- a/common/msft/private/service_contexts
+++ b/common/msft/private/service_contexts
@@ -1,0 +1,2 @@
+virtual_keyboard                          u:object_r:virtual_keyboard_service:s0
+cross_device_service                      u:object_r:cross_device_service:s0

--- a/common/msft/private/virtual_keyboard.te
+++ b/common/msft/private/virtual_keyboard.te
@@ -1,0 +1,32 @@
+# Copyright (C) 2023 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+type virtual_keyboard, domain, coredomain;
+type virtual_keyboard_exec, system_file_type, exec_type, file_type;
+
+init_daemon_domain(virtual_keyboard);
+
+binder_use(virtual_keyboard)
+binder_service(virtual_keyboard)
+add_service(virtual_keyboard, virtual_keyboard_service)
+
+# Needed to check app permissions.
+binder_call(virtual_keyboard, system_server)
+
+# Requires access to /dev/uinput to create and feed the virtual device.
+allow virtual_keyboard uhid_device:chr_file { w_file_perms ioctl };
+
+# Requires access to the package manager native service for clients'
+# package name check
+allow virtual_keyboard package_native_service:service_manager find;

--- a/common/sepolicy.mk
+++ b/common/sepolicy.mk
@@ -29,6 +29,11 @@ BOARD_VENDOR_SEPOLICY_DIRS += \
     hardware/google/pixel-sepolicy/turbo_adapter
 endif
 
+ifneq ($(BOARD_USES_QCOM_HARDWARE),true)
+SYSTEM_EXT_PRIVATE_SEPOLICY_DIRS += \
+    device/lineage/sepolicy/common/msft/private
+endif
+
 # Selectively include legacy rules defined by the products
 -include device/lineage/sepolicy/legacy-common/sepolicy.mk
 


### PR DESCRIPTION
* from: https://github.com/LineageOS/android_device_qcom_sepolicy/commit/b18d5721694ed09cdc3e8e6bcd505792f98380ff


Change-Id: I59e156d85d339831a14d4378b83d0c93e94ea74f